### PR TITLE
Fix webpack issue. Remove deprecated chrome plugin

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,14 @@
+/*
+ * ATTENTION: The "eval" devtool has been used (maybe by default in mode: "development").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses "eval()" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with "devtool: false".
+ * If you are looking for production-ready output files, see mode: "production" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	
+/******/ 	
+/******/ })()
+;

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "@testing-library/react": "^12.1.5",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^18.2.1",
-    "babel-loader": "^8.1.0",
-    "css-loader": "^5.2.7",
+    "babel-loader": "^9.1.2",
+    "css-loader": "^6.7.3",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^8.39.0",
@@ -42,12 +42,11 @@
     "jest-webextension-mock": "^3.6.1",
     "prettier": "^2.8.8",
     "recoil": "^0.7.7",
-    "style-loader": "^2.0.0",
+    "style-loader": "^3.3.2",
     "ts-loader": "^8.4.0",
     "typescript": "^5.0.4",
-    "webpack": "^4.43.0",
-    "webpack-chrome-extension-reloader": "^1.3.0",
-    "webpack-cli": "^3.3.12"
+    "webpack": "^5.81.0",
+    "webpack-cli": "^5.0.2"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.5.0",
@@ -69,6 +68,7 @@
     "jest-webextension-mock": "^3.6.1",
     "jsondiffpatch": "^0.4.1",
     "multiselect-react-dropdown": "^1.7.0",
+    "node-polyfill-webpack-plugin": "^2.0.1",
     "npm": "^9.6.5",
     "prop-types": "^15.7.2",
     "rc-slider": "^9.7.5",
@@ -84,8 +84,8 @@
     "react-spring": "^8.0.27",
     "redux-persist": "^6.0.0",
     "rxjs": "^6.6.2",
-    "semantic-ui-react": "^1.1.1",
-    "style-loader": "^2.0.0"
+    "sass-loader": "^13.2.2",
+    "semantic-ui-react": "^1.1.1"
   },
   "engines": {
     "node": "^10.12.0 || >=12.0.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const ChromeExtensionReloader = require('webpack-chrome-extension-reloader');
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 
 const config = {
   entry: {
@@ -44,19 +44,12 @@ const config = {
   resolve: {
     extensions: ['.tsx', '.ts', '.js', '.jsx'],
   },
-  plugins: [],
+  plugins: [new NodePolyfillPlugin()],
 };
 
-module.exports = (env, argv) => {
-  if (argv.mode === 'development') {
-    config.plugins.push(
-      new ChromeExtensionReloader({
-        entries: {
-          contentScript: ['app', 'content'],
-          background: ['background'],
-        },
-      }),
-    );
-  }
-  return config;
-};
+// module.exports = {
+//   // Other rules...
+//   plugins: [new NodePolyfillPlugin()],
+// };
+
+module.exports = config;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The build was crashing due to outdated dependencies. Updated to latest version of webpack and loaders. Removed chrome extension reloader. This fixed issues with node 18.
## Approach
<!--- How does your change address the problem? -->
 Updated to latest version of webpack and loaders. Removed chrome extension reloader. This fixed issues with node 18.
## Resources
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
